### PR TITLE
Fix time-based password seeding

### DIFF
--- a/eio_userdb/logic.py
+++ b/eio_userdb/logic.py
@@ -72,7 +72,7 @@ def register(form):
         db.session.commit()
 
         # Now add a non-activated user to the database, register a participation, and send activation email
-        p = hashlib.sha256((app.config['MAGIC'] + str(time) + form.username.data).encode('utf8')).hexdigest()[:10]
+        p = hashlib.sha256((app.config['MAGIC'] + str(time()) + form.username.data).encode('utf8')).hexdigest()[:10]
         u = User(first_name=form.first_name.data,
                  last_name=form.last_name.data,
                  username=form.username.data,


### PR DESCRIPTION
Upon registration, a password is generated by taking the first 10 characters of the SHA256 hash digest of: a magic string, a string representation of the current time and the user's username concatenated together.

The time component did not work, as the time function was not called and thus the string representation always produced the same result. (`'<built-in function time>'`) As such, users with the same username would always have the same random password.